### PR TITLE
Removing "/auth" from paths.

### DIFF
--- a/R/ShinyAuth_Keycloak.R
+++ b/R/ShinyAuth_Keycloak.R
@@ -9,16 +9,16 @@ ShinyAuth_Keycloak = R6::R6Class(
   public = list(
 
     #' @field url_auth_template URL template for auth entrypoint.
-    url_auth_template = 'https://{auth_domain}/auth/realms/{realm}/protocol/openid-connect/auth?client_id={client_id}&redirect_uri={encoded_redirect_uri}&response_type=code&state={state}&scope={encoded_scope}',
+    url_auth_template = 'https://{auth_domain}/realms/{realm}/protocol/openid-connect/auth?client_id={client_id}&redirect_uri={encoded_redirect_uri}&response_type=code&state={state}&scope={encoded_scope}',
 
     #' @field url_token_template URL template for token entrypoint.
-    url_token_template = 'https://{auth_domain}/auth/realms/{realm}/protocol/openid-connect/token',
+    url_token_template = 'https://{auth_domain}/realms/{realm}/protocol/openid-connect/token',
 
     #' @field url_userinfo_template URL template for userinfo entrypoint.
-    url_userinfo_template = 'https://{auth_domain}/auth/realms/{realm}/protocol/openid-connect/userinfo',
+    url_userinfo_template = 'https://{auth_domain}/realms/{realm}/protocol/openid-connect/userinfo',
 
     #' @field url_logout_template URL template for logout entrypoint.
-    url_logout_template = 'https://{auth_domain}/auth/realms/{realm}/protocol/openid-connect/logout?redirect_uri={encoded_redirect_uri}',
+    url_logout_template = 'https://{auth_domain}/realms/{realm}/protocol/openid-connect/logout?redirect_uri={encoded_redirect_uri}',
 
     #' @description
     #' Initialize Keycloak authentication for shiny app

--- a/inst/examples/extended/app.R
+++ b/inst/examples/extended/app.R
@@ -7,10 +7,10 @@ ShinyAuth_LocalKeycloak = R6::R6Class(
   'ShinyAuth_LocalKeycloak',
   inherit = ShinyAuth::ShinyAuth_Keycloak,
   public = list(
-    url_auth_template = 'http://{auth_domain}/auth/realms/{realm}/protocol/openid-connect/auth?client_id={client_id}&redirect_uri={encoded_redirect_uri}&response_type=code&state={state}&scope={encoded_scope}',
-    url_token_template = 'http://{auth_domain}/auth/realms/{realm}/protocol/openid-connect/token',
-    url_userinfo_template = 'http://{auth_domain}/auth/realms/{realm}/protocol/openid-connect/userinfo',
-    url_logout_template = 'http://{auth_domain}/auth/realms/{realm}/protocol/openid-connect/logout?redirect_uri={encoded_redirect_uri}'
+    url_auth_template = 'http://{auth_domain}/realms/{realm}/protocol/openid-connect/auth?client_id={client_id}&redirect_uri={encoded_redirect_uri}&response_type=code&state={state}&scope={encoded_scope}',
+    url_token_template = 'http://{auth_domain}/realms/{realm}/protocol/openid-connect/token',
+    url_userinfo_template = 'http://{auth_domain}/realms/{realm}/protocol/openid-connect/userinfo',
+    url_logout_template = 'http://{auth_domain}/realms/{realm}/protocol/openid-connect/logout?redirect_uri={encoded_redirect_uri}'
   )
 )
 

--- a/tests/testthat/test-keycloak.R
+++ b/tests/testthat/test-keycloak.R
@@ -19,10 +19,10 @@ test_that('Testing entrypoint URLs is correct', {
     auth_domain = 'auth.example.org',
     realm = 'realm_test'
   )
-  expect_equal(auth$url_auth(state = 'state_test'), 'https://auth.example.org/auth/realms/realm_test/protocol/openid-connect/auth?client_id=client_id_test&redirect_uri=http%3A%2F%2F127.0.0.1%3A3838%2F&response_type=code&state=state_test&scope=openid%20profile%20email')
-  expect_equal(auth$url_token(), 'https://auth.example.org/auth/realms/realm_test/protocol/openid-connect/token')
-  expect_equal(auth$url_userinfo(), 'https://auth.example.org/auth/realms/realm_test/protocol/openid-connect/userinfo')
-  expect_equal(auth$url_logout(), 'https://auth.example.org/auth/realms/realm_test/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2F127.0.0.1%3A3838%2F')
+  expect_equal(auth$url_auth(state = 'state_test'), 'https://auth.example.org/realms/realm_test/protocol/openid-connect/auth?client_id=client_id_test&redirect_uri=http%3A%2F%2F127.0.0.1%3A3838%2F&response_type=code&state=state_test&scope=openid%20profile%20email')
+  expect_equal(auth$url_token(), 'https://auth.example.org/realms/realm_test/protocol/openid-connect/token')
+  expect_equal(auth$url_userinfo(), 'https://auth.example.org/realms/realm_test/protocol/openid-connect/userinfo')
+  expect_equal(auth$url_logout(), 'https://auth.example.org/realms/realm_test/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2F127.0.0.1%3A3838%2F')
 })
 
 test_that('Custom logout url works', {
@@ -33,7 +33,7 @@ test_that('Custom logout url works', {
     auth_domain = 'auth.example.org',
     realm = 'realm_test'
   )
-  expect_equal(auth$url_logout(return_url = 'http://logout.example.org/'), 'https://auth.example.org/auth/realms/realm_test/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Flogout.example.org%2F')
+  expect_equal(auth$url_logout(return_url = 'http://logout.example.org/'), 'https://auth.example.org/realms/realm_test/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Flogout.example.org%2F')
 })
 
 test_that('Override scope works', {
@@ -45,7 +45,7 @@ test_that('Override scope works', {
     realm = 'realm_test',
     scope = 'openid profile email role_list'
   )
-  expect_equal(auth$url_auth(state = 'state_test'), 'https://auth.example.org/auth/realms/realm_test/protocol/openid-connect/auth?client_id=client_id_test&redirect_uri=http%3A%2F%2F127.0.0.1%3A3838%2F&response_type=code&state=state_test&scope=openid%20profile%20email%20role_list')
+  expect_equal(auth$url_auth(state = 'state_test'), 'https://auth.example.org/realms/realm_test/protocol/openid-connect/auth?client_id=client_id_test&redirect_uri=http%3A%2F%2F127.0.0.1%3A3838%2F&response_type=code&state=state_test&scope=openid%20profile%20email%20role_list')
 })
 
 test_that('We can override url templates', {


### PR DESCRIPTION
Since Keycloak 17, "/auth" is removed from the default context path.
Making changes to support ONLY keykloak >= 17.